### PR TITLE
Return created player

### DIFF
--- a/src/Manager/RainlinkPlayerManager.ts
+++ b/src/Manager/RainlinkPlayerManager.ts
@@ -23,7 +23,8 @@ export class RainlinkPlayerManager extends RainlinkDatabase<RainlinkPlayer> {
    * @internal
    */
 	async create(options: VoiceChannelOptions): Promise<RainlinkPlayer> {
-		if (this.get(options.guildId)) throw new Error('This guild already have an existing player');
+		const createdPlayer = this.get(options.guildId);
+		if (createdPlayer) return createdPlayer;
 		const getCustomNode = this.manager.nodes.get(String(options.nodeName ? options.nodeName : ''));
 		const node = getCustomNode ? getCustomNode : await this.manager.nodes.getLeastUsed();
 		if (!node) throw new Error('Can\'t find any nodes to connect on');


### PR DESCRIPTION
Instead of throwing an error, just return the created player, idk... I think it's a better idea than the error...
If you don't like the idea, simply close the PR.

I solved the *"issue"* with this:

![image](https://github.com/RainyXeon/Rainlink/assets/71156616/1e3c0591-cedf-4d4d-87fe-714b3b344bfa)

And that's why it occurred to me that it's better return the created player, because in the case of play command is where the player is created the first time.